### PR TITLE
add rubocop fail

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true
 
     - name: Run RuboCop
-      run: bundle exec rubocop
+      run: bundle exec rubocop --fail-level error
     
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
This PR adds `--fail-level error` to RuboCop to fail the build on offenses.