### PR TITLE
remove error level flag from rubocop ci run

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true
 
     - name: Run RuboCop
-      run: bundle exec rubocop --fail-level error
+      run: bundle exec rubocop --fail-level
     
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
This pr removes error level flag from rubocop in ci run