### PR TITLE
remove rubocop fail level flag

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -27,7 +27,7 @@ jobs:
         bundler-cache: true
 
     - name: Run RuboCop
-      run: bundle exec rubocop --fail-level
+      run: bundle exec rubocop
     
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
this PR removes fail level flag from rubocop run on CI